### PR TITLE
[#1] Add a description for each Extension

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -201,6 +201,18 @@ Please read the [MongoDB section](https://docs.axoniq.io/reference-guide/extensi
 
 ### Multitenancy
 
+The [Multitenancy Extension](https://github.com/AxonFramework/extension-multitenancy) repository provides integrated support for [multitenancy](https://en.wikipedia.org/wiki/Multitenancy) to your Axon Framework application.
+
+By adding this extension to your [Axon Framework](#axon-framework) application(s), you receive multi-tenant versions of all the infrastructure components the framework provides.
+In doing so, you can run a single instance of an application but serve many of your tenants in one go.
+Interfaces like the `CommandBus`, `EventProcessor`, and `SequencedDeadLetterQueue` are implemented by this extension to delegate tenant-specific tasks to concrete implementations of these components.
+
+If you combine Axon Framework and the Multitenancy Extension with [Axon Server](https://axoniq.io/product-overview/axon-server), the multitenancy experience of your app(s) is seamless.
+The extension achieves this by utilizing Axon Server's [multi-context](https://docs.axoniq.io/reference-guide/axon-server/administration/multi-context) behavior to dynamically create new tenants (read: a context per tenant) whenever you register them.
+It is usable without Axon Server, but you will be inclined to implement factories for the infrastructure components yourself.
+
+Please read the [Multitenancy](https://github.com/AxonFramework/extension-multitenancy/blob/main/README.md) `README.md` for more information about this extension.
+
 ### Reactor
 
 ### Spring Cloud

--- a/profile/README.md
+++ b/profile/README.md
@@ -106,6 +106,16 @@ For more details about each extension, we refer to the subsections below.
 
 ### AMQP
 
+The [AMQP Extension](https://github.com/AxonFramework/extension-amqp) repository provides support for the [Advanced Message Queuing Protocol](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) (AMQP).
+
+Users can add this extension to, for example, include a [RabbitMQ](https://www.rabbitmq.com/) integration with their Axon Framework application.
+Setting up this integration allows you to publish Axon events onto and read from a queue.
+In doing so, you would enable (micro)service communication, supporting event streaming.
+
+You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers event routing.
+
+Please read the [AMQP section](https://docs.axoniq.io/reference-guide/extensions/spring-amqp) of the documentation for more information about this extension.
+
 ### JGroups
 
 ### JobRunr Pro

--- a/profile/README.md
+++ b/profile/README.md
@@ -147,6 +147,23 @@ Please read the [Jobrunr Pro section](https://docs.axoniq.io/reference-guide/ext
 
 ### Kafka
 
+The [Kafka Extension](https://github.com/AxonFramework/extension-kafka) repository enables integration with [Kafka](https://kafka.apache.org/).
+
+Setting up a Kafka integration with your Axon Framework applications allows you to:
+1. Publish Axon Event Messages onto one or more Kafka topics, and
+2. to read Kafka Consumer Records converted to Axon Event Messages into your `@EventHandler` annotated methods.
+
+In doing so, you would enable (micro)service communication through event streaming.
+Or, you can attach a (third-party) application with your Axon Framework application, communicating through Kafka.
+
+Note that the Axon Framework team **does not** intend to support [Event Sourcing](https://developer.axoniq.io/event-sourcing/overview) through the Kafka Extension.
+Although there are Kafka-focused articles explaining how to achieve this, we find this a suboptimal solution leading to predicaments in the future.
+We thus suggest you choose [Axon Server](https://axoniq.io/product-overview/axon-server), an RDBMS solution or the [MongoDB Extension](#mongodb) to store your events and subsequently support event sourcing.
+
+You should regard this extension as a partial replacement of Axon Server as, compared to Axon Server, it only covers event streaming.
+
+Please read the [Kafka section](https://docs.axoniq.io/reference-guide/extensions/kafka) of the documentation for more information about this extension.
+
 ### Kotlin
 
 ### MongoDB

--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,7 @@ Although the main repository, [Axon Framework](https://github.com/AxonFramework/
 * **[Extensions](#extensions)** 
     * **[AMQP](#amqp)** - Extension adding [AMQP](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) support for event streaming
     * **[JGroups](#jgroups)** - Extension adding [JGroups](http://www.jgroups.org/) integration for command routing
-    * **[JobRunr Pro](#jobrunr-pro)** - Extensions adding [JobRunr](https://www.jobrunr.io/en/) Pro integration for deadline management and event scheduling
+    * **[JobRunr Pro](#jobrunr-pro)** - Extensions adding [JobRunr](https://www.jobrunr.io/en/) Pro integration for deadline management
     * **[Kafka](#kafka)** - Extension adding [Kafka](https://kafka.apache.org/) integration for event streaming
     * **[Kotlin](#kotlin)** - Extension enhancing the development experience when using [Kotlin](https://kotlinlang.org/)
     * **[MongoDB](#mongodb)** - Extension adding [MongoDB](https://www.mongodb.com/) integration for all Axon Framework components requiring storage
@@ -131,6 +131,17 @@ You should regard this extension as a partial replacement of [Axon Server](https
 Please read the [JGroups section](https://docs.axoniq.io/reference-guide/extensions/jgroups) of the documentation for more information about this extension.
 
 ### JobRunr Pro
+
+The [JobRunr Pro Extension](https://github.com/AxonFramework/extension-jobrunrpro) repository provides support for the "pro" edition of [JobRunr](https://www.jobrunr.io/en/).
+
+Users can benefit from this extension whenever they have:
+
+1. Acquired [JobRunr Pro](https://www.jobrunr.io/en/pricing/), and
+2. want to use Axon's [deadline management](https://docs.axoniq.io/reference-guide/axon-framework/deadlines/deadline-managers) functionality.
+
+We constructed this extension as some feature on the `DeadlineManager` API cannot be supported with the free edition of JobRunr.
+
+Please read the [Jobrunr Pro section](https://docs.axoniq.io/reference-guide/extensions/jobrunrpro) of the documentation for more information about this extension.
 
 ### Kafka
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -215,6 +215,13 @@ Please read the [Multitenancy](https://github.com/AxonFramework/extension-multit
 
 ### Reactor
 
+The [Reactor Extension](https://github.com/AxonFramework/extension-reactor) repository provides [Axon Framework](#axon-framework) infrastructure components using the [Project Reactor](https://projectreactor.io/) API.
+
+You can add this extension to your Axon Framework project to use results like `Mono` and `Flux` on framework components.
+It provides Reactor versions of Axon's gateways, allowing you to leverage the reactive API on the edge of your Axon Framework application.
+
+Please read the [Reactor section](https://docs.axoniq.io/reference-guide/extensions/reactor) of the documentation for more information about this extension.
+
 ### Spring Cloud
 
 ### Spring Native

--- a/profile/README.md
+++ b/profile/README.md
@@ -238,6 +238,16 @@ Please read the [Spring Cloud section](https://docs.axoniq.io/reference-guide/ex
 
 ### Spring Native
 
+The [Spring Native Extension](https://github.com/AxonFramework/extension-spring-native) repository enables integration with the [Spring Native](https://github.com/spring-attic/spring-native) project.
+
+This extension allows you to compile to a native image whenever you combine Axon Framework with Spring.
+
+Note that the current Spring Native Extension is an experimental release.
+The extension is experimental since the project we based it on is an experimental release too.
+
+As an experimental release, you may expect rigorous changes in the API whenever a new release is published.
+Please keep that in mind when using this extension.
+
 ### Tracing
 
 ## Bill of Materials

--- a/profile/README.md
+++ b/profile/README.md
@@ -253,6 +253,21 @@ Please keep that in mind when using this extension.
 
 ### Tracing
 
+The [Tracing Extension](https://github.com/AxonFramework/extension-tracing) repository enables integration with [Open Tracing](https://opentracing.io/).
+
+When using this extension, you will replace the `Command-` and `QueryGateway` with implementations that attach span information to your `Messages`.
+Furthermore, when handling a `Message`, a dedicated `MessageHandlerInterceptor` ensures the span is populated on the overall trace.
+
+Although this is valuable, it is essential to mention that the Open Tracing implementation has been archived in favor of [Open Telemetry](https://opentelemetry.io/).
+Furthermore, as of [Axon Framework](#axon-framework) version [4.6.0](https://github.com/AxonFramework/AxonFramework/releases/tag/axon-4.6.0), the framework provides native support for Open Telemetry.
+
+We thus recommend that you use the [integrated tracing support](https://docs.axoniq.io/reference-guide/axon-framework/monitoring/tracing) whenever you are on Axon Framework version 4.6 or above.
+
+Nonetheless, we still maintain and update the Tracing Extension for the time being.
+As such, you can be certain the extension still works as intended.
+
+Please read the [Tracing section](https://docs.axoniq.io/reference-guide/extensions/tracing) of the documentation for more information about this extension.
+
 ## Bill of Materials
 
 ## Inspector Axon

--- a/profile/README.md
+++ b/profile/README.md
@@ -224,6 +224,18 @@ Please read the [Reactor section](https://docs.axoniq.io/reference-guide/extensi
 
 ### Spring Cloud
 
+The [Spring Cloud Extension](https://github.com/AxonFramework/extension-springcloud) repository enables integration with [Spring Cloud](https://spring.io/projects/spring-cloud).
+
+You can use this extension to enable command routing in a distributed environment.
+As command routing differs from, for example, load balancing REST operation, it is highly recommended to use a distributed command routing solution whenever you have several applications and/or application instances that need to communicate with one another.
+
+The extension achieves this by implementing the `CommandRouter` and `CommandBusConnector`, consolidated in the `SpringCloudeCommandRouter` and `SpringHttpCommandBusConnector`, respectively.
+This connector provides the service discovery and message routing required to pass `CommandMessages` from one application (instance) to another.
+
+You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers command routing.
+
+Please read the [Spring Cloud section](https://docs.axoniq.io/reference-guide/extensions/spring-cloud) of the documentation for more information about this extension.
+
 ### Spring Native
 
 ### Tracing

--- a/profile/README.md
+++ b/profile/README.md
@@ -105,14 +105,15 @@ For more details about each extension, we refer to the subsections below.
  * **[Reactor](#reactor)** - Extension providing Axon Framework-specific infrastructure components using the [Project Reactor](https://projectreactor.io/) API 
  * **[Spring Cloud](#spring-cloud)** - Extension adding [Spring Cloud](https://spring.io/projects/spring-cloud) integration for command routing
  * **[Spring Native](#spring-native)** - Experimental extension providing native compilation for Axon and Spring-based application through the [Spring Native](https://github.com/spring-attic/spring-native) project.  
- * **[Tracing](#tracing)** - Extension adding [Open Tracing](https://opentracing.io/) integration to Axon's infrastructure components
+ * **[Tracing](#tracing)** - Extension adding [Open Tracing](https://opentracing.io/) integration to Axon's infrastructure components, superseded by integrated [Open Telemetry](https://opentelemetry.io/) support
 
 ### AMQP
 
 The [AMQP Extension](https://github.com/AxonFramework/extension-amqp) repository provides support for the [Advanced Message Queuing Protocol](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) (AMQP).
 
 Users can add this extension to, for example, include a [RabbitMQ](https://www.rabbitmq.com/) integration with their Axon Framework application.
-Setting up this integration allows you to publish Axon events to an AQMP exchange. Events can also be read from exchanges and handled by event processors, providing means of integrating with other services.
+Setting up this integration allows you to publish Axon events to an AMQP exchange. 
+Events can also be read from exchanges and handled by event processors, providing means of integrating with other services.
 
 In doing so, you would enable (micro)service communication through event streaming.
 Or, you can attach a (third-party) application with your Axon Framework application, communicating through AMQP.

--- a/profile/README.md
+++ b/profile/README.md
@@ -118,6 +118,18 @@ Please read the [AMQP section](https://docs.axoniq.io/reference-guide/extensions
 
 ### JGroups
 
+The [JGroups Extension](https://github.com/AxonFramework/extension-jgroups) repository enables integration with [JGroups](http://www.jgroups.org/).
+
+You can use this extension to enable command routing in a distributed environment.
+As command routing differs from, for example, load balancing REST operation, it is highly recommended to use a distributed command routing solution whenever you have several applications and/or application instances that need to communicate with one another.
+
+The extension achieves this by implementing the `CommandRouter` and `CommandBusConnector`, consolidated in the `JGroupsConnector`.
+This connector provides the service discovery and message routing required to pass `CommandMessages` from one application (instance) to another.
+
+You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers command routing.
+
+Please read the [JGroups section](https://docs.axoniq.io/reference-guide/extensions/jgroups) of the documentation for more information about this extension.
+
 ### JobRunr Pro
 
 ### Kafka

--- a/profile/README.md
+++ b/profile/README.md
@@ -166,6 +166,13 @@ Please read the [Kafka section](https://docs.axoniq.io/reference-guide/extension
 
 ### Kotlin
 
+The [Kotlin Extension](https://github.com/AxonFramework/extension-kotlin) repository eases Axon Framework development for [Kotlin](https://kotlinlang.org/)-based applications.
+
+You can use this extension to relieve some of the "awkwardness" of the Axon Framework API when used in combination with Kotlin.
+It does so by providing reified methods of several of Axon's infrastructure components, like the [command](https://docs.axoniq.io/reference-guide/axon-framework/axon-framework-commands/command-dispatchers#the-command-gateway) and [query gateway]( https://docs.axoniq.io/reference-guide/axon-framework/queries/query-dispatchers#the-query-bus-and-query-gateway), [upcasters](https://docs.axoniq.io/reference-guide/axon-framework/events/event-versioning#event-upcasting), and the [test fixtures](https://docs.axoniq.io/reference-guide/axon-framework/testing).
+
+Please read the [Kotlin section](https://docs.axoniq.io/reference-guide/extensions/kotlin) of the documentation for more information about this extension.
+
 ### MongoDB
 
 ### Multitenancy

--- a/profile/README.md
+++ b/profile/README.md
@@ -178,6 +178,27 @@ Please read the [Kotlin section](https://docs.axoniq.io/reference-guide/extensio
 
 ### MongoDB
 
+The [MongoDB Extension](https://github.com/AxonFramework/extension-mongo) repository enables [MongoDB](https://www.mongodb.com/) as a storage solution throughout the framework.
+
+Users can set this extension whenever they want to use MongoDB to store:
+- [Events](https://docs.axoniq.io/reference-guide/axon-framework/events/event-bus-and-event-store#event-store)
+- [Sagas](https://docs.axoniq.io/reference-guide/axon-framework/sagas)
+- [Tracking Tokens](https://docs.axoniq.io/reference-guide/axon-framework/events/event-processors/streaming#tracking-tokens)
+- [Dead Letters](https://docs.axoniq.io/reference-guide/axon-framework/events/event-processors#dead-letter-queue)
+
+Especially when you store Query Models or inside a MongoDB collection, we recommend you keep the tracking tokens of the [streaming processor](https://docs.axoniq.io/reference-guide/axon-framework/events/event-processors/streaming) inside MongoDB as well.
+By doing so, you ascertain that the framework uses a single transaction to update the model and token.
+
+The same logic applies to Sagas that are backed by streaming processors and stored in MongoDB; storing the tokens next to the saga instances makes the application more robust.
+
+Note that although you can use this extension to adjust MongoDB into an Event Store, we do not necessarily recommend this.
+During the lifecycle of this extension, we have noticed predicaments with how MongoDB behaves, causing the Event Store to act suboptimal from a performance perspective.
+We thus recommend either Axon Server (the highest level of performance for event storage) or an RDBMS of choice instead.
+
+You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers event storage.
+
+Please read the [MongoDB section](https://docs.axoniq.io/reference-guide/extensions/mongo) of the documentation for more information about this extension.
+
 ### Multitenancy
 
 ### Reactor

--- a/profile/README.md
+++ b/profile/README.md
@@ -112,7 +112,7 @@ For more details about each extension, we refer to the subsections below.
 The [AMQP Extension](https://github.com/AxonFramework/extension-amqp) repository provides support for the [Advanced Message Queuing Protocol](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) (AMQP).
 
 Users can add this extension to, for example, include a [RabbitMQ](https://www.rabbitmq.com/) integration with their Axon Framework application.
-Setting up this integration allows you to publish Axon events onto and read from a queue.
+Setting up this integration allows you to publish Axon events to an AQMP exchange. Events can also be read from exchanges and handled by event processors, providing means of integrating with other services.
 
 In doing so, you would enable (micro)service communication through event streaming.
 Or, you can attach a (third-party) application with your Axon Framework application, communicating through AMQP.

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,18 +8,7 @@ Although the main repository, [Axon Framework](https://github.com/AxonFramework/
 * **[Axon Framework](#axon-framework)** 
 * **[Getting Started](#getting-started)** 
 * **[Receiving Help](#receiving-help)**
-* **[Extensions](#extensions)** 
-    * **[AMQP](#amqp)** - Extension adding [AMQP](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) support for event streaming
-    * **[JGroups](#jgroups)** - Extension adding [JGroups](http://www.jgroups.org/) integration for command routing
-    * **[JobRunr Pro](#jobrunr-pro)** - Extensions adding [JobRunr](https://www.jobrunr.io/en/) Pro integration for deadline management
-    * **[Kafka](#kafka)** - Extension adding [Kafka](https://kafka.apache.org/) integration for event streaming
-    * **[Kotlin](#kotlin)** - Extension enhancing the development experience when using [Kotlin](https://kotlinlang.org/)
-    * **[MongoDB](#mongodb)** - Extension adding [MongoDB](https://www.mongodb.com/) integration for all Axon Framework components requiring storage
-    * **[Multitenancy](#multitenancy)** - Extension adding building blocks to simplify [multitenancy](https://en.wikipedia.org/wiki/Multitenancy), particularly straightforward in combination with [Axon Server](https://developer.axoniq.io/axon-server/overview)
-    * **[Reactor](#reactor)** - Extension providing Axon Framework-specific infrastructure components using the [Project Reactor](https://projectreactor.io/) API 
-    * **[Spring Cloud](#spring-cloud)** - Extension adding [Spring Cloud](https://spring.io/projects/spring-cloud) integration for command routing
-    * **[Spring Native](#spring-native)** - Experimental extension providing native compilation for Axon and Spring-based application through the [Spring Native](https://github.com/spring-attic/spring-native) project.  
-    * **[Tracing](#tracing)** - Extension adding [Open Tracing](https://opentracing.io/) integration to Axon's infrastructure components
+* **[Extensions](#extensions)**
 * **[Bill of Materials](#bill-of-materials)** 
 * **[Inspector Axon](#inspector-axon)** - Specialized monitoring and management tooling for Axon Framework applications.
 * **[IntelliJ IDEA Plugin](#intellij-idea-plugin)** - Plugin for IntelliJ IDEA simplifying Axon Framework development  
@@ -103,6 +92,20 @@ The extensions are intentionally split off from the main framework to not over e
 
 The functionality of the extensions ranges from event streaming integrations with [AMQP](#amqp) and [Kafka](#kafka), database tooling like [Mongo](#mongodb), and language-specific integrations as with the [Kotlin](#kotlin) extension.
 For more details about each extension, we refer to the subsections below.
+
+#### Contents
+
+ * **[AMQP](#amqp)** - Extension adding [AMQP](https://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol) support for event streaming
+ * **[JGroups](#jgroups)** - Extension adding [JGroups](http://www.jgroups.org/) integration for command routing
+ * **[JobRunr Pro](#jobrunr-pro)** - Extensions adding [JobRunr](https://www.jobrunr.io/en/) Pro integration for deadline management
+ * **[Kafka](#kafka)** - Extension adding [Kafka](https://kafka.apache.org/) integration for event streaming
+ * **[Kotlin](#kotlin)** - Extension enhancing the development experience when using [Kotlin](https://kotlinlang.org/)
+ * **[MongoDB](#mongodb)** - Extension adding [MongoDB](https://www.mongodb.com/) integration for all Axon Framework components requiring storage
+ * **[Multitenancy](#multitenancy)** - Extension adding building blocks to simplify [multitenancy](https://en.wikipedia.org/wiki/Multitenancy), particularly straightforward in combination with [Axon Server](https://developer.axoniq.io/axon-server/overview)
+ * **[Reactor](#reactor)** - Extension providing Axon Framework-specific infrastructure components using the [Project Reactor](https://projectreactor.io/) API 
+ * **[Spring Cloud](#spring-cloud)** - Extension adding [Spring Cloud](https://spring.io/projects/spring-cloud) integration for command routing
+ * **[Spring Native](#spring-native)** - Experimental extension providing native compilation for Axon and Spring-based application through the [Spring Native](https://github.com/spring-attic/spring-native) project.  
+ * **[Tracing](#tracing)** - Extension adding [Open Tracing](https://opentracing.io/) integration to Axon's infrastructure components
 
 ### AMQP
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -171,7 +171,7 @@ Please read the [Kafka section](https://docs.axoniq.io/reference-guide/extension
 
 The [Kotlin Extension](https://github.com/AxonFramework/extension-kotlin) repository eases Axon Framework development for [Kotlin](https://kotlinlang.org/)-based applications.
 
-You can use this extension to relieve some of the "awkwardness" of the Axon Framework API when used in combination with Kotlin.
+You can use this extension to relieve some of the "awkwardness" of the Axon Framework API when using Kotlin to build your application(s).
 It does so by providing reified methods of several of Axon's infrastructure components, like the [command](https://docs.axoniq.io/reference-guide/axon-framework/axon-framework-commands/command-dispatchers#the-command-gateway) and [query gateway]( https://docs.axoniq.io/reference-guide/axon-framework/queries/query-dispatchers#the-query-bus-and-query-gateway), [upcasters](https://docs.axoniq.io/reference-guide/axon-framework/events/event-versioning#event-upcasting), and the [test fixtures](https://docs.axoniq.io/reference-guide/axon-framework/testing).
 
 Please read the [Kotlin section](https://docs.axoniq.io/reference-guide/extensions/kotlin) of the documentation for more information about this extension.

--- a/profile/README.md
+++ b/profile/README.md
@@ -110,9 +110,11 @@ The [AMQP Extension](https://github.com/AxonFramework/extension-amqp) repository
 
 Users can add this extension to, for example, include a [RabbitMQ](https://www.rabbitmq.com/) integration with their Axon Framework application.
 Setting up this integration allows you to publish Axon events onto and read from a queue.
-In doing so, you would enable (micro)service communication, supporting event streaming.
 
-You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers event routing.
+In doing so, you would enable (micro)service communication through event streaming.
+Or, you can attach a (third-party) application with your Axon Framework application, communicating through AMQP.
+
+You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers event streaming.
 
 Please read the [AMQP section](https://docs.axoniq.io/reference-guide/extensions/spring-amqp) of the documentation for more information about this extension.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -232,6 +232,9 @@ As command routing differs from, for example, load balancing REST operation, it 
 The extension achieves this by implementing the `CommandRouter` and `CommandBusConnector`, consolidated in the `SpringCloudeCommandRouter` and `SpringHttpCommandBusConnector`, respectively.
 This connector provides the service discovery and message routing required to pass `CommandMessages` from one application (instance) to another.
 
+Since the implementation uses the Spring Cloud discovery interfaces to perform the service discovery, you are able to choose a multitude of implementations to enable distributed command routing.
+You can, for example, use implementation like [Netflix](https://spring.io/projects/spring-cloud-netflix), [Consul](https://spring.io/projects/spring-cloud-consul), [Zookeeper](https://spring.io/projects/spring-cloud-zookeeper), [Kubernetes](https://spring.io/projects/spring-cloud-kubernetes), and many more.
+
 You should regard this extension as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server) as, compared to Axon Server, it only covers command routing.
 
 Please read the [Spring Cloud section](https://docs.axoniq.io/reference-guide/extensions/spring-cloud) of the documentation for more information about this extension.


### PR DESCRIPTION
This pull request introduces short descriptions of each extension within the Axon Framework project.

More concretely, it introduces a section for the:

- AMQP extension
- JGroups extension
- JobRunrPro extension
- Kafka extension
- Kotlin extension
- Mongo extension
- Multitenancy extension
- Reactor extension
- Spring Cloud extension
- Spring Native extension
- Tracing extension

Lastly, it also moves the extensions contents section from the introduction to the dedicated Extensions section.

In providing the above, this pull request partially resolves issue #1.